### PR TITLE
New skip features

### DIFF
--- a/plugin/skipit.vim
+++ b/plugin/skipit.vim
@@ -25,6 +25,17 @@ fun! s:skipit()
 	endif
 endfun
 
+fun! s:skipitback()
+	let pattern='\v['.s:beginning_delimiters.s:ending_delimiters.s:quotes.']'
+	let pos = s:findprev(pattern)
+
+	if pos != [0, 0]
+		call setpos('.', [0, pos[0], pos[1], 0])
+	else
+		call setpos('.', [0, line('.'), 0])
+	endif
+endfun
+
 fun! s:skipall()
 	let pattern = '\v['.s:beginning_delimiters.s:ending_delimiters.']'
 	let pos = s:findnext(pattern)
@@ -71,9 +82,18 @@ endfun
 
 fun! s:findnext(pattern)
 	if(g:skipit_multiline)
+		" c - accept matches at the current cursor
 		return searchpos(a:pattern, 'ecW')
 	else
 		return searchpos(a:pattern, 'ec', line('.'))
+	endif
+endfun
+
+fun! s:findprev(pattern)
+	if(g:skipit_multiline)
+		return searchpos(a:pattern, 'beW')
+	else
+		return searchpos(a:pattern, 'be', line('.'))
 	endif
 endfun
 
@@ -86,10 +106,15 @@ fun! s:isin(char, string)
 endfun
 
 inoremap <silent> <Plug>SkipIt <C-\><C-O>:call <SID>skipit()<CR>
+inoremap <silent> <Plug>SkipItBack <C-\><C-O>:call <SID>skipitback()<CR>
 inoremap <silent> <Plug>SkipAll <C-\><C-O>:call <SID>skipall()<CR>
 
 if !hasmapto('<Plug>SkipIt') && maparg('<C-l>','i') ==# ''
 	imap <C-l> <Plug>SkipIt
+endif
+
+if !hasmapto('<Plug>SkipItBack') && maparg('<C-b>','i') ==# ''
+	imap <C-b> <Plug>SkipItBack
 endif
 
 if !hasmapto('<Plug>SkipAll') && maparg('<C-g>l','i') ==# ''

--- a/plugin/skipit.vim
+++ b/plugin/skipit.vim
@@ -50,7 +50,7 @@ fun! s:skipall()
 		else
 			let delimiters .= s:ending_delimiters
 		endif
-		
+
 		" All ignorable delimeters
 		let all_delimiters = delimiters.s:quotes."\s\t\n"
 		" Initialize the position for iterating the current buffer
@@ -94,7 +94,7 @@ fun! s:skipallback()
 		else
 			let delimiters .= s:ending_delimiters
 		endif
-		
+
 		" All ignorable delimeters
 		let all_delimiters = delimiters.s:quotes."\s\t\n"
 		" Initialize the position for iterating the current buffer
@@ -151,19 +151,19 @@ fun! s:isin(char, string)
 endfun
 
 inoremap <silent> <Plug>SkipIt <C-\><C-O>:call <SID>skipit()<CR>
-inoremap <silent> <Plug>SkipItBack <C-\><C-O>:call <SID>skipitback()<CR>
-inoremap <silent> <Plug>SkipAll <C-\><C-O>:call <SID>skipall()<CR>
+inoremap <silent> <Plug>SkipBack <C-\><C-O>:call <SID>skipitback()<CR>
+inoremap <silent> <Plug>SkipAllForward <C-\><C-O>:call <SID>skipall()<CR>
 inoremap <silent> <Plug>SkipAllBack <C-\><C-O>:call <SID>skipallback()<CR>
 
 if !hasmapto('<Plug>SkipIt') && maparg('<C-l>','i') ==# ''
 	imap <C-l> <Plug>SkipIt
 endif
 
-if !hasmapto('<Plug>SkipItBack') && maparg('<C-p>','i') ==# ''
-	imap <C-b> <Plug>SkipItBack
+if !hasmapto('<Plug>SkipBack') && maparg('<C-p>','i') ==# ''
+	imap <C-p> <Plug>SkipBack
 endif
 
-if !hasmapto('<Plug>SkipAll') && maparg('<C-g>l','i') ==# ''
+if !hasmapto('<Plug>SkipAllForward') && maparg('<C-g>l','i') ==# ''
 	imap <C-g>l <Plug>SkipAll
 endif
 

--- a/plugin/skipit.vim
+++ b/plugin/skipit.vim
@@ -159,7 +159,7 @@ if !hasmapto('<Plug>SkipIt') && maparg('<C-l>','i') ==# ''
 	imap <C-l> <Plug>SkipIt
 endif
 
-if !hasmapto('<Plug>SkipItBack') && maparg('<C-b>','i') ==# ''
+if !hasmapto('<Plug>SkipItBack') && maparg('<C-p>','i') ==# ''
 	imap <C-b> <Plug>SkipItBack
 endif
 
@@ -167,6 +167,6 @@ if !hasmapto('<Plug>SkipAll') && maparg('<C-g>l','i') ==# ''
 	imap <C-g>l <Plug>SkipAll
 endif
 
-if !hasmapto('<Plug>SkipAllBack') && maparg('<C-g>b','i') ==# ''
+if !hasmapto('<Plug>SkipAllBack') && maparg('<C-g>p','i') ==# ''
 	imap <C-g>b <Plug>SkipAllBack
 endif

--- a/plugin/skipit.vim
+++ b/plugin/skipit.vim
@@ -10,12 +10,13 @@ if !exists('g:skipit_multiline')
 	let g:skipit_multiline = 1
 endif
 
+let s:quotes = '"''`|'
+let s:beginning_delimiters = '[{(<'
+let s:ending_delimiters = '\])}>'
+
 fun! s:skipit()
-	if(g:skipit_multiline)
-		let pos = searchpos('\v[{([<"''|>\])}]', 'ecW')
-	else
-		let pos = searchpos('\v[{([<"''|>\])}]', 'ec', line('.'))
-	endif
+	let pattern='\v['.s:beginning_delimiters.s:ending_delimiters.s:quotes.']'
+	let pos = s:findnext(pattern)
 
 	if pos != [0, 0]
 		call setpos('.', [0, pos[0], pos[1]+1, 0])
@@ -24,8 +25,73 @@ fun! s:skipit()
 	endif
 endfun
 
+fun! s:skipall()
+	let pattern = '\v['.s:beginning_delimiters.s:ending_delimiters.']'
+	let pos = s:findnext(pattern)
+
+	if pos != [0, 0]
+		" Keep looking forward and find the true stop position
+		" First find out if we found a beginning delimiter or an ending
+		" delimiter, and keep looking for the same type of delimiter
+		let delimiters=''
+		if(s:isin(s:getcharat(pos), s:beginning_delimiters))
+			let delimiters .= s:beginning_delimiters
+		else
+			let delimiters .= s:ending_delimiters
+		endif
+		
+		" All ignorable delimeters
+		let all_delimiters = delimiters.s:quotes."\s\t\n"
+		" Initialize the position for iterating the current buffer
+		let curlinepos=pos[0]
+		let curpos=pos[1]
+		let lastlinepos=line('$')
+		let stop=0
+		while (curlinepos <= lastlinepos && !stop)
+			let curline=getline(curlinepos)
+			while (curpos <= len(curline) && !stop)
+				let curchar=s:getcharat([curlinepos, curpos])
+				if(s:isin(curchar, all_delimiters))
+					if(s:isin(curchar, delimiters))
+						let pos=[curlinepos, curpos+1]
+					endif
+					let curpos=curpos+1
+				else
+					let stop=1
+				endif
+			endwhile
+			let curlinepos=curlinepos+1
+			let curpos=1
+		endwhile
+		call setpos('.', [0, pos[0], pos[1]+1, 0])
+	else
+		call setpos('.', [0, line('.'), col('$')])
+	endif
+endfun
+
+fun! s:findnext(pattern)
+	if(g:skipit_multiline)
+		return searchpos(a:pattern, 'ecW')
+	else
+		return searchpos(a:pattern, 'ec', line('.'))
+	endif
+endfun
+
+fun! s:getcharat(pos)
+	return getline(a:pos[0])[a:pos[1] - 1]
+endfun
+
+fun! s:isin(char, string)
+	return stridx(a:string, a:char) >= 0
+endfun
+
 inoremap <silent> <Plug>SkipIt <C-\><C-O>:call <SID>skipit()<CR>
+inoremap <silent> <Plug>SkipAll <C-\><C-O>:call <SID>skipall()<CR>
 
 if !hasmapto('<Plug>SkipIt') && maparg('<C-l>','i') ==# ''
 	imap <C-l> <Plug>SkipIt
+endif
+
+if !hasmapto('<Plug>SkipAll') && maparg('<C-g>l','i') ==# ''
+	imap <C-g>l <Plug>SkipAll
 endif

--- a/plugin/skipit.vim
+++ b/plugin/skipit.vim
@@ -74,7 +74,7 @@ fun! s:skipall()
 			let curlinepos=curlinepos+1
 			let curpos=1
 		endwhile
-		call setpos('.', [0, pos[0], pos[1]+1, 0])
+		call setpos('.', [0, pos[0], pos[1], 0])
 	else
 		call setpos('.', [0, line('.'), col('$')])
 	endif


### PR DESCRIPTION
Hi, just got around to test a few new features around, thought you might want to take a look at them tell me what you think, and merge them if you want :)

I added 3 more features to the plugin: SkipAll, SkipBack and SkipAllBack. SkipBack is like SkipIt, only with the previous delimeter, SkipAll and SkipAllBack will skip all the delimiters ahead or back until they find a non-delimiter.
I mapped them by default too, `<C-g>l`, `<C-p>`, `<C-g>p` respectively. You might consider changingi the mapping of SkipIt to `<C-n>` by default, making it easier to remember as a mnemonic (Skip Next or Previous), or maybe even remove default mappings altogether.
I was thinking also of implementing smarter settings/mappings, where you can set things globally (`g:`), per buffer (`b:`), locally, etc, maybe also add custom delimiter setting...
Lastly got to update the documentation too.
Looking forward to your feedback!
